### PR TITLE
Version - complete revamp

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>slf4j-simple</artifactId>
             <version>2.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>24.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/shanebeestudios/mcdeop/McDeob.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/McDeob.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 public class McDeob {
 
     public static void main(String[] args) {
+        Version.initVersions();
         if (args.length == 0) {
             try {
                 if (Util.isRunningMacOS()) {
@@ -34,11 +35,11 @@ public class McDeob {
         parser.accepts("help", "Shows help and exits");
         parser.accepts("versions", "Prints a list of all Minecraft versions available to deobfuscate");
         parser.accepts("version", "Minecraft version for which we're deobfuscating")
-                .withRequiredArg()
-                .ofType(String.class);
+            .withRequiredArg()
+            .ofType(String.class);
         parser.accepts("type", "What we should deobfuscate: client or server")
-                .withRequiredArg()
-                .ofType(String.class);
+            .withRequiredArg()
+            .ofType(String.class);
         parser.accepts("decompile", "Marks that we should decompile the deobfuscated source");
 
         OptionSet options = parser.parse(args);
@@ -72,19 +73,21 @@ public class McDeob {
         String versionString = (String) options.valueOf("version");
         String typeString = (String) options.valueOf("type");
 
+        Version.Type type;
         try {
-            Version.Type.valueOf(typeString.toUpperCase());
+            type = Version.Type.valueOf(typeString.toUpperCase());
         } catch (IllegalArgumentException e) {
             Logger.error("Invalid type specified, shutting down...");
             System.exit(1);
+            return;
         }
 
-        Version.Type type = Version.Type.valueOf(typeString.toUpperCase());
-        Version version = Version.getByVersion(versionString, type);
+        Version version = Version.getByVersion(versionString);
         if (version == null) {
             Logger.error("Invalid or unsupported version was specified, shutting down...");
             System.exit(1);
         }
+        version.setType(type);
 
         boolean decompile = options.has("decompile");
 

--- a/src/main/java/com/shanebeestudios/mcdeop/Processor.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/Processor.java
@@ -6,20 +6,12 @@ import com.shanebeestudios.mcdeop.util.TimeStamp;
 import com.shanebeestudios.mcdeop.util.Util;
 import io.github.lxgaming.reconstruct.common.Reconstruct;
 import org.jetbrains.java.decompiler.main.decompiler.ConsoleDecompiler;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.json.JSONTokener;
 
 import java.awt.*;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.InvalidObjectException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -28,15 +20,6 @@ import java.util.stream.Stream;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 public class Processor {
-    private static final URL LATEST_INFO;
-
-    static {
-        try {
-            LATEST_INFO = new URL("https://launchermeta.mojang.com/mc/game/version_manifest.json");
-        } catch (MalformedURLException e) {
-            throw new AssertionError("Impossible");
-        }
-    }
 
     private final Version version;
     private final boolean decompile;
@@ -46,8 +29,6 @@ public class Processor {
     private Path jarPath;
     private Path mappingsPath;
     private Path remappedJar;
-    private String mappingsUrl;
-    private String jarUrl;
 
     private String minecraftJarName;
     private String mappingsName;
@@ -57,75 +38,75 @@ public class Processor {
 
     public Processor(Version version, boolean decompile, App app) {
         this.version = version;
+        this.decompile = decompile;
         this.app = app;
         if (Util.isRunningMacOS()) {
             // If running on macOS, put the output directory in the user home directory.
             // This is due to how macOS APPs work — their '.' directory resolves to one inside the APP itself.
-            dataFolderPath = Paths.get(System.getProperty("user.home"), "McDeob");
+            this.dataFolderPath = Paths.get(System.getProperty("user.home"), "McDeob");
         }
         try {
-            Files.createDirectories(dataFolderPath);
+            Files.createDirectories(this.dataFolderPath);
         } catch (IOException ignore) {
         }
-
-        minecraftJarName = String.format("minecraft_%s_%s.jar", version.getType().getName(), version.getVersion());
-        mappingsName = String.format("mappings_%s_%s.txt", version.getType().getName(), version.getVersion());
-        mappedJarName = String.format("remapped_%s_%s.jar", version.getType().getName(), version.getVersion());
-        jarUrl = version.getJar();
-        mappingsUrl = version.getMappings();
-        this.decompile = decompile;
-        this.reconstruct = new Reconstruct(new ReconConfig());
     }
 
     @SuppressWarnings("CallToPrintStackTrace")
     public void init() {
         try {
             long start = System.currentTimeMillis();
-            if (app != null) {
-                app.toggleControls();
+
+            // Prepare version and check if valid
+            String versionName = this.version.getVersion();
+            if (!this.version.prepareVersion()) {
+                if (this.app != null) {
+                    this.app.fail();
+                } else {
+                    System.out.println("Invalid version: " + versionName);
+                }
+                return;
+            }
+            if (this.app != null) {
+                this.app.toggleControls();
             }
 
-            if (version.isLatest()) {
-                String trueVersion = prepareLatest();
-                if (app != null) {
-                    app.addVersionBox(trueVersion);
-                }
-            }
+            String versionTypeName = this.version.getType().getName();
+            this.minecraftJarName = String.format("minecraft_%s_%s.jar", versionTypeName, versionName);
+            this.mappingsName = String.format("mappings_%s_%s.txt", versionTypeName, versionName);
+            this.mappedJarName = String.format("remapped_%s_%s.jar", versionTypeName, versionName);
+            this.reconstruct = new Reconstruct(new ReconConfig());
 
             downloadJar();
             downloadMappings();
             remapJar();
-            if (decompile) {
+            if (this.decompile) {
                 decompileJar();
             }
             cleanup();
 
             TimeStamp timeStamp = TimeStamp.fromNow(start);
             Logger.info("Completed in %s!", timeStamp);
-            if (app != null) {
-                app.updateStatusBox(String.format("Completed in %s!", timeStamp));
-                app.updateButton("Start!");
+            if (this.app != null) {
+                this.app.updateStatusBox(String.format("Completed in %s!", timeStamp));
+                this.app.updateButton("Start!");
+                this.app.toggleControls();
             }
         } catch (IOException e) {
             e.printStackTrace();
-        } finally {
-            if (app != null) {
-                app.toggleControls();
-            }
         }
     }
 
     public void downloadJar() throws IOException {
         long start = System.currentTimeMillis();
         Logger.info("Downloading JAR file from Mojang.");
-        if (app != null) {
-            app.updateStatusBox("Downloading JAR...");
-            app.updateButton("Downloading JAR...", Color.BLUE);
+        if (this.app != null) {
+            this.app.updateStatusBox("Downloading JAR...");
+            this.app.updateButton("Downloading JAR...", Color.BLUE);
         }
 
-        jarPath = dataFolderPath.resolve(minecraftJarName);
-        final URL parsedURL = new URL(jarUrl);
-        final HttpURLConnection connection = (HttpURLConnection) parsedURL.openConnection();
+        this.jarPath = this.dataFolderPath.resolve(this.minecraftJarName);
+        final URL jarURL = new URL(this.version.getJarURL());
+        final HttpURLConnection connection = (HttpURLConnection) jarURL.openConnection();
         final long length = connection.getContentLengthLong();
         if (Files.exists(jarPath) && Files.size(jarPath) == length) {
             Logger.info("Already have JAR, skipping download.");
@@ -140,18 +121,18 @@ public class Processor {
     public void downloadMappings() throws IOException {
         long start = System.currentTimeMillis();
         Logger.info("Downloading mappings file from Mojang...");
-        if (app != null) {
-            app.updateStatusBox("Downloading mappings...");
-            app.updateButton("Downloading mappings...", Color.BLUE);
+        if (this.app != null) {
+            this.app.updateStatusBox("Downloading mappings...");
+            this.app.updateButton("Downloading mappings...", Color.BLUE);
         }
-        final URL parsedURL = new URL(mappingsUrl);
-        final HttpURLConnection connection = (HttpURLConnection) parsedURL.openConnection();
+        final URL mappingURL = new URL(this.version.getMapURL());
+        final HttpURLConnection connection = (HttpURLConnection) mappingURL.openConnection();
         final long length = connection.getContentLengthLong();
-        mappingsPath = dataFolderPath.resolve(mappingsName);
-        if (Files.exists(mappingsPath) && Files.size(mappingsPath) == length) {
+        this.mappingsPath = this.dataFolderPath.resolve(this.mappingsName);
+        if (Files.exists(this.mappingsPath) && Files.size(this.mappingsPath) == length) {
             Logger.info("Already have mappings, skipping download.");
         } else try (final InputStream inputStream = connection.getInputStream()) {
-            Files.copy(inputStream, mappingsPath, REPLACE_EXISTING);
+            Files.copy(inputStream, this.mappingsPath, REPLACE_EXISTING);
         }
 
         TimeStamp timeStamp = TimeStamp.fromNow(start);
@@ -160,41 +141,41 @@ public class Processor {
 
     public void remapJar() {
         long start = System.currentTimeMillis();
-        if (app != null) {
-            app.updateStatusBox("Remapping...");
-            app.updateButton("Remapping...", Color.BLUE);
+        if (this.app != null) {
+            this.app.updateStatusBox("Remapping...");
+            this.app.updateButton("Remapping...", Color.BLUE);
         }
-        remappedJar = dataFolderPath.resolve(mappedJarName);
+        this.remappedJar = this.dataFolderPath.resolve(this.mappedJarName);
 
         if (!Files.exists(remappedJar)) {
-            Logger.info("Remapping %s file...", minecraftJarName);
-            reconstruct.getConfig().setInputPath(jarPath.toAbsolutePath());
-            reconstruct.getConfig().setMappingPath(mappingsPath.toAbsolutePath());
-            reconstruct.getConfig().setOutputPath(remappedJar.toAbsolutePath());
-            reconstruct.load();
+            Logger.info("Remapping %s file...", this.minecraftJarName);
+            this.reconstruct.getConfig().setInputPath(this.jarPath.toAbsolutePath());
+            this.reconstruct.getConfig().setMappingPath(this.mappingsPath.toAbsolutePath());
+            this.reconstruct.getConfig().setOutputPath(this.remappedJar.toAbsolutePath());
+            this.reconstruct.load();
 
             TimeStamp timeStamp = TimeStamp.fromNow(start);
             Logger.info("Remapping completed in %s!", timeStamp);
         } else {
-            Logger.info("%s already remapped... skipping mapping.", mappedJarName);
+            Logger.info("%s already remapped... skipping mapping.", this.mappedJarName);
         }
     }
 
     public void decompileJar() throws IOException {
         long start = System.currentTimeMillis();
         Logger.info("Decompiling final JAR file.");
-        if (app != null) {
-            app.updateStatusBox("Decompiling... This will take a while!");
-            app.updateButton("Decompiling...", Color.BLUE);
+        if (this.app != null) {
+            this.app.updateStatusBox("Decompiling... This will take a while!");
+            this.app.updateButton("Decompiling...", Color.BLUE);
         }
-        final Path decompileDir = dataFolderPath.resolve("final-decompile");
+        final Path decompileDir = this.dataFolderPath.resolve("final-decompile");
         Files.createDirectories(decompileDir);
 
         // Setup FernFlower to properly decompile the jar file
         String[] args = new String[]{
             "-dgs=1", "-hdc=0", "-rbr=0",
             "-asc=1", "-udv=0", "-rsy=1",
-            remappedJar.toAbsolutePath().toString(),
+            this.remappedJar.toAbsolutePath().toString(),
             decompileDir.toAbsolutePath().toString()
         };
 
@@ -214,90 +195,11 @@ public class Processor {
         Logger.info("Decompiling completed in %s!", timeStamp);
     }
 
-    public String prepareLatest() throws IOException {
-        if (app != null) {
-            app.updateStatusBox("Fetching version list from Mojang...");
-            app.updateButton("Fetching...");
-        }
-
-        URLConnection connection = LATEST_INFO.openConnection();
-        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        final JSONObject versions = new JSONObject(new JSONTokener(in));
-        in.close();
-
-
-        if (!versions.has("latest")) {
-            String s = "Failed! Could not locate the latest data from the downloaded manifest file!";
-            Logger.error(s);
-            if (app != null) {
-                app.updateStatusBox(s);
-                app.updateButton("Exit");
-            }
-            throw new InvalidObjectException(s);
-        }
-
-        String type = version == Version.SERVER_LATEST_RELEASE || version == Version.CLIENT_LATEST_RELEASE ? "release" : "snapshot";
-
-        String trueVersion = versions.getJSONObject("latest").getString(type);
-        Logger.info("Finding the URL for " + trueVersion);
-        if (app != null) {
-            app.updateStatusBox("Finding the URL for " + trueVersion);
-        }
-
-        String versionURL = null;
-
-        JSONArray versionArray = versions.getJSONArray("versions");
-        for (int i = 0; i < versionArray.length(); i++) {
-            JSONObject innerVersion = versionArray.getJSONObject(i);
-
-            String id = innerVersion.getString("id");
-            if (id.equalsIgnoreCase(trueVersion)) {
-                versionURL = innerVersion.getString("url");
-                break;
-            }
-        }
-
-        if (versionURL == null) {
-            String s = "Failed! Could not find information for version " + trueVersion + "!";
-            Logger.error(s);
-            if (app != null) {
-                app.updateStatusBox(s);
-                app.updateButton("Exit");
-            }
-            throw new InvalidObjectException(s);
-        }
-
-        Logger.info("Download data for " + trueVersion + "...");
-        if (app != null) {
-            app.updateStatusBox("Download data for " + trueVersion + "...");
-        }
-
-        connection = new URL(versionURL).openConnection();
-        in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        JSONObject versionManifest = new JSONObject(new JSONTokener(in));
-        in.close();
-
-        JSONObject downloads = versionManifest.getJSONObject("downloads");
-        String clientOrServer = version.getType().getName().toLowerCase();
-        jarUrl = downloads.getJSONObject(clientOrServer).getString("url");
-        mappingsUrl = downloads.getJSONObject(clientOrServer + "_mappings").getString("url");
-
-        minecraftJarName = String.format("minecraft_%s_%s.jar", clientOrServer, trueVersion);
-        mappingsName = String.format("mappings_%s_%s.txt", clientOrServer, trueVersion);
-        mappedJarName = String.format("remapped_%s_%s.jar", clientOrServer, trueVersion);
-
-        Logger.info("Found the jar and mappings url for " + trueVersion + "!");
-        if (app != null) {
-            app.updateStatusBox("Found the JAR and mappings URL for " + trueVersion + "!");
-        }
-        return trueVersion;
-    }
-
     private void cleanup() {
-        jarPath = null;
-        mappingsPath = null;
-        remappedJar = null;
-        reconstruct = null;
+        this.jarPath = null;
+        this.mappingsPath = null;
+        this.remappedJar = null;
+        this.reconstruct = null;
         System.gc();
     }
 

--- a/src/main/java/com/shanebeestudios/mcdeop/Version.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/Version.java
@@ -1,165 +1,115 @@
 package com.shanebeestudios.mcdeop;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import com.shanebeestudios.mcdeop.util.Util;
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 
-@SuppressWarnings("unused")
-public enum Version {
+public class Version {
 
-    // Latest
-    SERVER_LATEST_RELEASE(Type.SERVER, "Latest_Release", null, null),
-    CLIENT_LATEST_RELEASE(Type.CLIENT, "Latest_Release", null, null),
-    SERVER_LATEST_SNAPSHOT(Type.SERVER, "Latest_Snapshot", null, null),
-    CLIENT_LATEST_SNAPSHOT(Type.CLIENT, "Latest_Snapshot", null, null),
+    // Static Stuff
+    private static final Map<String, Version> VERSION_MAP = new TreeMap<>(Collections.reverseOrder());
 
-    // Release
-    SERVER_1_20_4(Type.SERVER, "1.20.4", "8dd1a28015f51b1803213892b50b7b4fc76e594d", "c1cafe916dd8b58ed1fe0564fc8f786885224e62"),
-    CLIENT_1_20_4(Type.CLIENT, "1.20.4", "fd19469fed4a4b4c15b2d5133985f0e3e7816a8a", "be76ecc174ea25580bdc9bf335481a5192d9f3b7"),
-    SERVER_1_20_3(Type.SERVER, "1.20.3", "4fb536bfd4a83d61cdbaf684b8d311e66e7d4c49", "c1cafe916dd8b58ed1fe0564fc8f786885224e62"),
-    CLIENT_1_20_3(Type.CLIENT, "1.20.3", "b178a327a96f2cf1c9f98a45e5588d654a3e4369","be76ecc174ea25580bdc9bf335481a5192d9f3b7"),
-    SERVER_1_20_2(Type.SERVER, "1.20.2", "5b868151bd02b41319f54c8d4061b8cae84e665c", "dced504a9b5df367ddd3477adac084cea8024ba4"),
-    CLIENT_1_20_2(Type.CLIENT, "1.20.2", "82d1974e75fc984c5ed4b038e764e50958ac61a0", "5c292ff7d3161977041116698e295083fd5ec8f5"),
-    SERVER_1_20_1(Type.SERVER, "1.20.1", "84194a2f286ef7c14ed7ce0090dba59902951553", "0b4dba049482496c507b2387a73a913230ebbd76"),
-    CLIENT_1_20_1(Type.CLIENT, "1.20.1", "0c3ec587af28e5a785c0b4a7b8a30f9a8f78f838", "6c48521eed01fe2e8ecdadbd5ae348415f3c47da"),
-    SERVER_1_20(Type.SERVER, "1.20", "15c777e2cfe0556eef19aab534b186c0c6f277e1", "15e61168fd24c7950b22cd3b9e771a7ce4035b41"),
-    CLIENT_1_20(Type.CLIENT, "1.20", "e575a48efda46cf88111ba05b624ef90c520eef1", "a4cd9a97400f7ecfe4dba23e427549ebc5815d66"),
-    SERVER_1_19_4(Type.SERVER, "1.19.4", "8f3112a1049751cc472ec13e397eade5336ca7ae", "73c8bb982e420b33aad9632b482608c5c33e2d13"),
-    CLIENT_1_19_4(Type.CLIENT, "1.19.4", "958928a560c9167687bea0cefeb7375da1e552a8", "f14771b764f943c154d3a6fcb47694477e328148"),
-    SERVER_1_19_3(Type.SERVER, "1.19.3", "c9df48efed58511cdd0213c56b9013a7b5c9ac1f", "bc44f6dd84cd2f3ad8c0caad850eaca9e82067e3"),
-    CLIENT_1_19_3(Type.CLIENT, "1.19.3", "977727ec9ab8b4631e5c12839f064092f17663f8", "42366909cc612e76208d34bf1356f05a88e08a1d"),
-    SERVER_1_19_2(Type.SERVER, "1.19.2", "f69c284232d7c7580bd89a5a4931c3581eae1378", "ed5e6e8334ad67f5af0150beed0f3d156d74bd57"),
-    CLIENT_1_19_2(Type.CLIENT, "1.19.2", "055b30d860ead928cba3849ba920c88b6950b654", "8e8c9be5dc27802caba47053d4fdea328f7f89bd"),
-    SERVER_1_19_1(Type.SERVER, "1.19.1", "8399e1211e95faa421c1507b322dbeae86d604df", "3565648cdd47ae15738fb804a95a659137d7cfd3"),
-    CLIENT_1_19_1(Type.CLIENT, "1.19.1", "90d438c3e432add8848a9f9f368ce5a52f6bc4a7", "fc8e22d42c0e4eb1899e2acf7e97eae917e1cb94"),
-    SERVER_1_19(Type.SERVER, "1.19", "e00c4052dac1d59a1188b2aa9d5a87113aaf1122", "1c1cea17d5cd63d68356df2ef31e724dd09f8c26"),
-    CLIENT_1_19(Type.CLIENT, "1.19", "c0898ec7c6a5a2eaa317770203a1554260699994", "150346d1c0b4acec0b4eb7f58b86e3ea1aa730f3"),
-    SERVER_1_18_2(Type.SERVER, "1.18.2", "c8f83c5655308435b3dcf03c06d9fe8740a77469", "e562f588fea155d96291267465dc3323bfe1551b"),
-    CLIENT_1_18_2(Type.CLIENT, "1.18.2", "2e9a3e3107cca00d6bc9c97bf7d149cae163ef21", "a661c6a55a0600bd391bdbbd6827654c05b2109c"),
-    SERVER_1_18_1(Type.SERVER, "1.18.1", "125e5adf40c659fd3bce3e66e67a16bb49ecc1b9", "9717df2acd926bd4a9a7b2ce5f981bb7e4f7f04a"),
-    CLIENT_1_18_1(Type.CLIENT, "1.18.1", "7e46fb47609401970e2818989fa584fd467cd036", "99ade839eacf69b8bed88c91bd70ca660aee47bb"),
-    SERVER_1_18(Type.SERVER, "1.18", "3cf24a8694aca6267883b17d934efacc5e44440d", "a8fe854e35a69df7289d3f03fc0821f6363f2238"),
-    CLIENT_1_18(Type.CLIENT, "1.18", "d49eb6caed53d23927648c97451503442f9e26fd", "e824c89c612c0b9cb438ef739c44726c59bbf679"),
-    SERVER_1_17_1(Type.SERVER, "1.17.1", "a16d67e5807f57fc4e550299cf20226194497dc2", "f6cae1c5c1255f68ba4834b16a0da6a09621fe13"),
-    CLIENT_1_17_1(Type.CLIENT, "1.17.1", "8d9b65467c7913fcf6f5b2e729d44a1e00fde150", "e4d540e0cba05a6097e885dffdf363e621f87d3f"),
-    SERVER_1_17(Type.SERVER, "1.17", "0a269b5f2c5b93b1712d0f5dc43b6182b9ab254e", "84d80036e14bc5c7894a4fad9dd9f367d3000334"),
-    CLIENT_1_17(Type.CLIENT, "1.17", "1cf89c77ed5e72401b869f66410934804f3d6f52", "227d16f520848747a59bef6f490ae19dc290a804"),
-    SERVER_1_16_5(Type.SERVER, "1.16.5", "1b557e7b033b583cd9f66746b7a9ab1ec1673ced", "41285beda6d251d190f2bf33beadd4fee187df7a"),
-    CLIENT_1_16_5(Type.CLIENT, "1.16.5", "37fd3c903861eeff3bc24b71eed48f828b5269c8", "374c6b789574afbdc901371207155661e0509e17"),
-    SERVER_1_16_4(Type.SERVER, "1.16.4", "35139deedbd5182953cf1caa23835da59ca3d7cd", "d9ae0e8e28475254855430ff051daaa0dd041a08"),
-    CLIENT_1_16_4(Type.CLIENT, "1.16.4", "1952d94a0784e7abda230aae6a1e8fc0522dba99", "0837de813d1a6b67e23da3c520a84e872c8d2f0e"),
-    SERVER_1_16_3(Type.SERVER, "1.16.3", "f02f4473dbf152c23d7d484952121db0b36698cb", "e75ff1e729aec4a3ec6a94fe1ddd2f5a87a2fd00"),
-    CLIENT_1_16_3(Type.CLIENT, "1.16.3", "1321521b2caf934f7fc9665aab7e059a7b2bfcdf", "faac5028fbca3859db970cc4ca041aeec55f6d9d"),
-    SERVER_1_16_2(Type.SERVER, "1.16.2", "c5f6fb23c3876461d46ec380421e42b289789530", "0dbbb5aae568c2d9aa34e3be11e7b525054265d9"),
-    CLIENT_1_16_2(Type.CLIENT, "1.16.2", "653e97a2d1d76f87653f02242d243cdee48a5144", "88fbd1c70c9244d23e6166a9703cc456d6f115e6"),
-    SERVER_1_16_1(Type.SERVER, "1.16.1", "a412fd69db1f81db3f511c1463fd304675244077", "a11471890ef5bdc4025dd7a587a46f106d56a7da"),
-    CLIENT_1_16_1(Type.CLIENT, "1.16.1", "c9abbe8ee4fa490751ca70635340b7cf00db83ff", "588f9a7260759c0c10e193162f76fde005a46fe2"),
-    SERVER_1_16(Type.SERVER, "1.16", "a0d03225615ba897619220e256a266cb33a44b6b", "a11471890ef5bdc4025dd7a587a46f106d56a7da"),
-    CLIENT_1_16(Type.CLIENT, "1.16", "228fdf45541c4c2fe8aec4f20e880cb8fcd46621", "c04e0f0d37414fc022ca31062acb0ff1d67be331"),
-    SERVER_1_15_2(Type.SERVER, "1.15.2", "bb2b6b1aefcd70dfd1892149ac3a215f6c636b07", "e018f7413ad5b98d7427bc3027c95c78845e891b"),
-    CLIENT_1_15_2(Type.CLIENT, "1.15.2", "e3f78cd16f9eb9a52307ed96ebec64241cc5b32d", "e101497d78faca35dec18f632de16c25899b6f08"),
-    SERVER_1_15_1(Type.SERVER, "1.15.1", "4d1826eebac84847c71a77f9349cc22afd0cf0a1", "d10e23f8def30fcf7d0a0d027f48f2731d80208f"),
-    CLIENT_1_15_1(Type.CLIENT, "1.15.1", "8b11614bea9293592a947ea8f4fd72981ea66677", "24c55605b6ebd4ee0b28d41d609b68599ef23c67"),
-    SERVER_1_15(Type.SERVER, "1.15", "e9f105b3c5c7e85c7b445249a93362a22f62442d", "c79e5ee9c5167b730266910d4c5bafbaf27c2f52"),
-    CLIENT_1_15(Type.CLIENT, "1.15", "7b07fd09d1e3aae1bc7a1304fedc73bfe5d81800", "a0bea08f0b96f6f30a350cd75270be63f7d0aac4"),
-    SERVER_1_14_4(Type.SERVER, "1.14.4", "3dc3d84a581f14691199cf6831b71ed1296a9fdf", "46a7ba37c15820f00d49eafb38afb4a9bb64a0be"),
-    CLIENT_1_14_4(Type.CLIENT, "1.14.4", "8c325a0c5bd674dd747d6ebaa4c791fd363ad8a9", "3a0e42172d082f18c4ee0b4561a6a2ecc9868a58"),
+    public static void initVersions() {
+        JSONObject versionManifest;
+        try {
+            versionManifest = Util.getJsonFromURL("https://launchermeta.mojang.com/mc/game/version_manifest.json");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
 
-    // Combat Test
-    SERVER_COMBAT_TEST_8c(Type.SERVER, "Combat_Test_8c", "b707c44ac1503ad179fde86c78d41aa4d0cc78a5", "d89f9e0eb8fbe6f2c91e749e8b59391cd0dd96d4"),
-    CLIENT_COMBAT_TEST_8c(Type.CLIENT, "Combat_Test_8c", "177472ace3ff5d98fbd63b4bcd5bbef5b035a018", "5ea38a7b8d58837c97214f2a46e5e12151d51f83"),
+        for (Object o : versionManifest.getJSONArray("versions")) {
+            JSONObject versionObject = (JSONObject) o;
+            String version = versionObject.getString("id");
+            String releaseType = versionObject.getString("type");
+            String url = versionObject.getString("url");
 
-    // April Fools
-    SERVER_23w13a_or_b(Type.SERVER, "23w13TheVoteUpdate", "6241fc14ce7a659f371683a72aa24c155f60cce1", "370d31c1b7d700ee65ddeb25f975a2e67d1d13d0"),
-    CLIENT_23w13a_or_b(Type.CLIENT, "23w13TheVoteUpdate", "8ebf103ef3c48ff40d4d002f44c5f7bc5d90e7e2", "89796dd1e08c190821ecdd31e3c43709a66b010b"),
-    SERVER_22w13one(Type.SERVER, "22w13oneBlockAtATime", "5f48eea55c7fd1881d9c63835b15dfb5bbcd3a67", "2c55055b906935ffe1e7e7cb80d1a8b031eb9f95"),
-    CLIENT_22w13one(Type.CLIENT, "22w13oneBlockAtATime", "6548ac25265c2726a2cd24dec3820c07ee2b0b4b", "b1bbd68dbf48041dd994f1a4c1a3eacfa46e344b"),
-    SERVER_20w14infinite(Type.SERVER, "20w14infinite", "c0711cd9608d1af3d6f05ac423dd8f4199780225", "a94a32e698caff0f5c5762b3dca045ddcd587071"),
-    CLIENT_20w14infinite(Type.CLIENT, "20w14infinite", "cc5cb23748614a6396ffb77427b4f11f4b6ae99b", "3d91233a24c5de720f0eb41927a0b00e45e89caa");
+            VERSION_MAP.put(version, new Version(version, releaseType, url));
 
-    private final Type type;
-    private final String version;
-    private final String jar;
-    private final String mappings;
-
-    Version(Type type, String version, String jar, String mappings) {
-        this.type = type;
-        this.version = version;
-        this.jar = jar + "/" + type.getName() + ".jar";
-        this.mappings = mappings + "/" + type.getName() + ".txt";
-    }
-
-    public String getVersion() {
-        return version;
-    }
-
-    public String getJar() {
-        return OBJECTS + jar;
-    }
-
-    public String getMappings() {
-        return OBJECTS + mappings;
-    }
-
-    public Type getType() {
-        return type;
-    }
-
-    public boolean isLatest() {
-        return this == CLIENT_LATEST_RELEASE || this == SERVER_LATEST_RELEASE
-                || this == CLIENT_LATEST_SNAPSHOT || this == SERVER_LATEST_SNAPSHOT;
-    }
-
-    @Override
-    public String toString() {
-        return "Version{" +
-                "type=" + type +
-                ", version='" + version + '\'' +
-                '}';
-    }
-
-    private static final String OBJECTS = "https://launcher.mojang.com/v1/objects/";
-    private static final Map<String, Version> SERVER_VERSION_MAP = new HashMap<>();
-    private static final Map<String, Version> CLIENT_VERSION_MAP = new HashMap<>();
-    private static final List<Version> AVAILABLE_VERSIONS = new ArrayList<>();
-
-    public static List<Version> getVersions() {
-        return AVAILABLE_VERSIONS;
-    }
-
-    static {
-        for (Version ver : values()) {
-            if (ver.type == Type.SERVER) {
-                SERVER_VERSION_MAP.put(ver.getVersion().toLowerCase(), ver);
-                AVAILABLE_VERSIONS.add(ver);
-            } else {
-                CLIENT_VERSION_MAP.put(ver.getVersion().toLowerCase(), ver);
+            // Mappings not available before 1.14.4, so we exit
+            if (version.equalsIgnoreCase("1.14.4")) {
+                return;
             }
         }
     }
 
-    public static Version getByVersion(String ver, Type type) {
-        if (type == Type.SERVER) {
-            return SERVER_VERSION_MAP.get(ver.toLowerCase());
-        } else {
-            return CLIENT_VERSION_MAP.get(ver.toLowerCase());
+    public static Collection<Version> getVersions() {
+        return VERSION_MAP.values();
+    }
+
+    @Nullable
+    public static Version getByVersion(String version) {
+        return VERSION_MAP.get(version);
+    }
+
+    // Class Stuff
+    private final String version;
+    private final String releaseType;
+    private final String url;
+
+    private Type type;
+    private String jarURL;
+    private String mapURL;
+
+    public Version(String version, String releaseType, String url) {
+        this.version = version;
+        this.releaseType = releaseType;
+        this.url = url;
+    }
+
+    public boolean prepareVersion() {
+        try {
+            JSONObject versionInfo = Util.getJsonFromURL(this.url);
+            JSONObject downloads = versionInfo.getJSONObject("downloads");
+            if (downloads.has("server_mappings")) {
+                String typeName = this.type.getName();
+                this.jarURL = downloads.getJSONObject(typeName).getString("url");
+                this.mapURL = downloads.getJSONObject(typeName + "_mappings").getString("url");
+                return true;
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
         }
+        return false;
+    }
+
+    public String getVersion() {
+        return this.version;
+    }
+
+    public String getReleaseType() {
+        return this.releaseType;
+    }
+
+    public Type getType() {
+        return this.type;
+    }
+
+    public void setType(Type type) {
+        this.type = type;
+    }
+
+    public String getJarURL() {
+        return this.jarURL;
+    }
+
+    public String getMapURL() {
+        return this.mapURL;
     }
 
     public enum Type {
-        SERVER("server"), CLIENT("client");
-
-        private final String name;
-
-        Type(String name) {
-            this.name = name;
-        }
+        SERVER,
+        CLIENT;
 
         public String getName() {
-            return name;
+            return name().toLowerCase(Locale.ROOT);
         }
-
     }
 
 }

--- a/src/main/java/com/shanebeestudios/mcdeop/util/Util.java
+++ b/src/main/java/com/shanebeestudios/mcdeop/util/Util.java
@@ -1,9 +1,33 @@
 package com.shanebeestudios.mcdeop.util;
 
+import org.json.JSONObject;
+import org.json.JSONTokener;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.net.URLConnection;
+
 public class Util {
 
     public static boolean isRunningMacOS() {
         return System.getProperty("os.name").contains("Mac OS");
+    }
+
+    /**
+     * Get a JsonObject from a URL
+     *
+     * @param url URL to grab data from
+     * @return JsonObject with retrieved data
+     * @throws IOException Error thrown if data cannot be retrieved
+     */
+    public static JSONObject getJsonFromURL(String url) throws IOException {
+        URLConnection connection = new URL(url).openConnection();
+        BufferedReader in = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        final JSONObject jsonObject = new JSONObject(new JSONTokener(in));
+        in.close();
+        return jsonObject;
     }
 
 }


### PR DESCRIPTION
This PR aims to completely revamp the Version class.
## CHANGES:
- Completely wiped Version class, no more need for hardcoding
- Versions are pulled from the Mojang version manifest at runtime
- A list will generate of all versions that are available to map
- A button was added to toggle between snapshots and releases
- The text box showing which version was chosen was removed
- Minor cleanup was done in several areas

Ref #41 